### PR TITLE
Use `template = FALSE` instead of `fragment.only = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     testthat,
     knitr,
     rmarkdown,
-    markdown,
+    markdown (>= 1.3),
     yaml,
     Biobase,
     datasets,

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -44,7 +44,7 @@ knit_ex <- function(x, ..., quiet = TRUE, open = FALSE){
     }
     x <- paste0(x, collapse = "\n")
     if( any(html_chunks) ){
-        res <- knitr::knit2html(text = x, ..., fragment.only = TRUE, quiet = quiet)
+        res <- knitr::knit2html(text = x, ..., template = FALSE, quiet = quiet)
         if( open ){
             tmp <- tempfile("knit_ex", fileext = '.html')
             cat(res, file = tmp, sep = "\n") 


### PR DESCRIPTION
The argument `fragment.only` will be deprecated in future: https://github.com/rstudio/markdown/blob/master/NEWS.md#changes-in-markdown-version-13

Thanks!